### PR TITLE
Create new S3 terraform modules

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -78,6 +78,14 @@ locals {
       description : "Terraform module to create N number of state machines with custom IAM policies..",
       topics : ["terraform", "aws", "iac", "module"]
     },
+    "sudoblark.terraform.module.aws.s3_bucket" : {
+      description : "Terraform module to create N number of S3 buckets.",
+      topics : ["terraform", "aws", "iac", "module"]
+    },
+    "sudoblark.terraform.module.aws.s3_bucket_notifications" : {
+      description : "Terraform module create N number of notifications on a given S3 bucket.",
+      topics : ["terraform", "aws", "iac", "module"]
+    },
   }
 
 


### PR DESCRIPTION
# Description

Create new repos to host s3_bucket and s3_bucket_notification modules respectively.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] See terraform plan in this PR

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Terraform validate works locally
- [x] Terraform plan passes in the pipeline with an expected result
- [x] Terraform plan does not show any unsuspected terraform destroy operations
