### PR TITLE
Make demo repos public

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,8 +3,15 @@ locals {
     "sudoblark.terraform.modularised-demo" : {
       description : "An example Terraform setup using modularised components to fulfill a use-case",
       topics : ["terraform", "aws", "iac", "demo"]
-      open_source : true
-    }
+      open_source : true,
+      visibility : "public"
+    },
+    "sudoblark.terraform.module.aws.s3_files" : {
+      description : "Terraform module to upload N number of (optionally templated) local files to S3 with distinct keys.",
+      topics : ["terraform", "aws", "iac", "module"],
+      open_source : true,
+      visibility : "public"
+    },
   }
 
   core_platform = {
@@ -60,10 +67,6 @@ locals {
     },
     "sudoblark.terraform.module.aws.lambda" : {
       description : "Terraform module to create N number of lambdas from ZIPs or URIs.",
-      topics : ["terraform", "aws", "iac", "module"]
-    },
-    "sudoblark.terraform.module.aws.s3_files" : {
-      description : "Terraform module to upload N number of (optionally templated) local files to S3 with distinct keys.",
       topics : ["terraform", "aws", "iac", "module"]
     },
     "sudoblark.terraform.module.aws.security_group" : {


### PR DESCRIPTION
- And change licensing

# Description

This change simply makes demo repos required for the DevOps society conference in November live to the general public, and changes licensing appropriately.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] See CI workflow for plan of changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Terraform validate works locally
- [x] Terraform plan passes in the pipeline with an expected result
- [x] Terraform plan does not show any unsuspected terraform destroy operations
