### PR TITLE
Make monsternames api public

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -38,6 +38,7 @@ locals {
       description : "Lambda container for the monsternames-api RESTAPI backend.",
       topics : ["aws", "python", "docker"],
       open_source : true,
+      visibility = "public"
     }
   }
 


### PR DESCRIPTION
# Description

Now that monsternames.api has been refracted into modern Terraform, we should make it live.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Fully deployed and tested and confirmed ready to be visible.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Terraform validate works locally
- [x] Terraform plan passes in the pipeline with an expected result
- [x] Terraform plan does not show any unsuspected terraform destroy operations
