### PR TITLE
Add in new repo to store custom GitHub Actions agent

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -32,6 +32,12 @@ locals {
       visibility : "public"
       open_source : true
     },
+    "sudoblark.github-actions.agent" : {
+      description : "An example custom CI/CD agent for GitHub Actions, complete with localised kubernetes deployment.",
+      topics : ["github-actions", "docker", "kubernetes"]
+      visibility : "private"
+      open_source : true
+    },
     "sudoblark.github-actions.workflows" : {
       description : "Template library of re-usable, end-to-end, workflows for GitHub Actions.",
       topics : ["yaml", "github-actions", "workflows"]


### PR DESCRIPTION
# Description

At the last CI/CD talk I gave at DevOps Society, one of the questions revolved around how to create, and host, your own CI/CD agents.

So I figured I'd get a repo setup to show how to do just this.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

See CI tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Terraform validate works locally
- [x] Terraform plan passes in the pipeline with an expected result
- [x] Terraform plan does not show any unsuspected terraform destroy operations
